### PR TITLE
feat!: per-instance caches, context manager, stricter log redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0rc3] - Unreleased
+
+### Added
+- Context manager protocol on `GenAIKeys`: `with GenAIKeys.azure() as sk: ...` automatically clears cached secrets on exit (#9).
+- Stronger redaction guarantee: backend exception messages are no longer interpolated into log records — only the exception type is logged, so a misbehaving backend cannot leak a secret value via logs (#10).
+- Regression test asserting per-instance cache isolation across backends.
+
+### Changed
+- **BREAKING:** `GenAIKeys` is no longer a singleton. Each call to `GenAIKeys(...)` (and the `azure()`/`aws()`/`gcp()`/`backend()` factories) now returns a fresh instance with its own private cache. This eliminates the cross-backend cache collision where a second `GenAIKeys.aws()` call would return the cached value of an earlier `GenAIKeys.azure()` call for the same secret name (#12, #15).
+- `SingletonMeta` is no longer exported from the package.
+
+### Removed
+- `SingletonMeta` metaclass on `GenAIKeys`.
+- Stray `del os.environ[secret_name]` call inside `invalidate_cache` (dead code).
+
 ## [1.0.0] - 2026-04-20
 
 First GA release.

--- a/genaikeys/__init__.py
+++ b/genaikeys/__init__.py
@@ -2,7 +2,7 @@ import logging as _stdlib_logging
 from importlib.metadata import PackageNotFoundError, version
 
 from ._logging import disable_logging, enable_logging
-from .keeper import GenAIKeys, SingletonMeta
+from .keeper import GenAIKeys
 from .plugins import SecretManagerPlugin
 
 try:
@@ -15,7 +15,6 @@ _stdlib_logging.getLogger(__name__).addHandler(_stdlib_logging.NullHandler())
 __all__ = [
     "GenAIKeys",
     "SecretManagerPlugin",
-    "SingletonMeta",
     "__version__",
     "enable_logging",
     "disable_logging",

--- a/genaikeys/backends/aws.py
+++ b/genaikeys/backends/aws.py
@@ -33,7 +33,7 @@ class AWSSecretsManagerPlugin(SecretManagerPlugin):
         try:
             response = self.client.get_secret_value(SecretId=secret_name)
         except Exception as exc:
-            logger.error("AWS get_secret_value failed for %r: %s", secret_name, exc)
+            logger.error("AWS get_secret_value failed for %r: %s", secret_name, type(exc).__name__)
             raise
         return str(response["SecretString"])
 

--- a/genaikeys/backends/azure.py
+++ b/genaikeys/backends/azure.py
@@ -40,7 +40,7 @@ class AzureKeyVaultPlugin(SecretManagerPlugin):
         try:
             secret = self.client.get_secret(normalized)
         except Exception as exc:
-            logger.error("Azure Key Vault get_secret failed for %r: %s", normalized, exc)
+            logger.error("Azure Key Vault get_secret failed for %r: %s", normalized, type(exc).__name__)
             raise
         value = secret.value
         if value is None:

--- a/genaikeys/backends/gcp.py
+++ b/genaikeys/backends/gcp.py
@@ -27,7 +27,7 @@ class GCPSecretManagerPlugin(SecretManagerPlugin):
             response = self.client.access_secret_version(request={"name": name})
             return response.payload.data.decode("UTF-8")
         except Exception as exc:
-            logger.error("GCP access_secret_version failed for %r: %s", secret_name, exc)
+            logger.error("GCP access_secret_version failed for %r: %s", secret_name, type(exc).__name__)
             raise
 
     def list_secrets(self, max_results: int = 100) -> list[str]:

--- a/genaikeys/cache.py
+++ b/genaikeys/cache.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import threading
 import time
 from typing import Any
@@ -39,7 +38,7 @@ class InMemorySecretManager:
                     "backend %s failed to fetch %r: %s",
                     type(self._plugin).__name__,
                     secret_name,
-                    exc,
+                    type(exc).__name__,
                 )
                 raise
             self._cache[secret_name] = {"value": secret_value, "timestamp": current_time}
@@ -54,8 +53,6 @@ class InMemorySecretManager:
             elif secret_name in self._cache:
                 logger.debug("invalidating cache entry %r", secret_name)
                 del self._cache[secret_name]
-                if secret_name in os.environ:
-                    del os.environ[secret_name]
 
     def __repr__(self) -> str:
         return f"<InMemorySecretManager backend={type(self._plugin).__name__} entries=redacted>"

--- a/genaikeys/keeper.py
+++ b/genaikeys/keeper.py
@@ -1,6 +1,5 @@
 import logging
 import re
-import threading
 
 from .cache import InMemorySecretManager
 from .plugins import SecretManagerPlugin, load_backend
@@ -14,19 +13,7 @@ def _is_secret_attr(name: str) -> bool:
     return bool(_SECRET_ATTR_RE.match(name))
 
 
-class SingletonMeta(type):
-    _instances: dict[type, object] = {}
-    _lock = threading.Lock()
-
-    def __call__(cls, *args, **kwargs):
-        if cls not in cls._instances:
-            with cls._lock:
-                if cls not in cls._instances:
-                    cls._instances[cls] = super().__call__(*args, **kwargs)
-        return cls._instances[cls]
-
-
-class GenAIKeys(metaclass=SingletonMeta):
+class GenAIKeys:
     def __init__(self, plugin: SecretManagerPlugin, cache_duration: int = 3600):
         self._manager = InMemorySecretManager(plugin, cache_duration)
         logger.info(
@@ -80,6 +67,12 @@ class GenAIKeys(metaclass=SingletonMeta):
     def get_gemini_key(self) -> str:
         return self.get("GEMINI_API_KEY")
 
+    def __enter__(self) -> "GenAIKeys":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.clear()
+
     def __getattr__(self, name: str) -> str:
         if name.startswith("_") or not _is_secret_attr(name):
             raise AttributeError(name)
@@ -109,10 +102,3 @@ class GenAIKeys(metaclass=SingletonMeta):
 
     def __deepcopy__(self, memo):
         raise TypeError("GenAIKeys is not copyable: refusing to duplicate cached secrets")
-
-
-_SECRET_ATTR_RE = __import__("re").compile(r"^[A-Z][A-Z0-9_]*$")
-
-
-def _is_secret_attr(name: str) -> bool:
-    return bool(_SECRET_ATTR_RE.match(name))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,15 +3,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from genaikeys import SingletonMeta
-
-
-@pytest.fixture(autouse=True)
-def reset_singleton():
-    SingletonMeta._instances.clear()
-    yield
-    SingletonMeta._instances.clear()
-
 
 @pytest.fixture
 def mock_cloud_backends():

--- a/tests/test_genaikeys.py
+++ b/tests/test_genaikeys.py
@@ -25,11 +25,31 @@ class TestGenAIKeys:
         sk.get("MY_SECRET")
         assert "MY_SECRET" not in os.environ
 
-    def test_singleton_returns_same_instance(self):
+    def test_each_instantiation_returns_new_instance(self):
         plugin = FakePlugin({"K": "v"})
         sk1 = GenAIKeys(plugin)
         sk2 = GenAIKeys(plugin)
-        assert sk1 is sk2
+        assert sk1 is not sk2
+
+    def test_context_manager_clears_cache_on_exit(self):
+        plugin = FakePlugin({"K": "v"})
+        with GenAIKeys(plugin) as sk:
+            sk.get("K")
+            assert plugin.call_count == 1
+            sk.get("K")
+            assert plugin.call_count == 1
+        sk.get("K")
+        assert plugin.call_count == 2
+
+    def test_instances_have_isolated_caches(self):
+        plugin_a = FakePlugin({"SHARED_NAME": "value-from-a"})
+        plugin_b = FakePlugin({"SHARED_NAME": "value-from-b"})
+        sk_a = GenAIKeys(plugin_a)
+        sk_b = GenAIKeys(plugin_b)
+        assert sk_a.get("SHARED_NAME") == "value-from-a"
+        assert sk_b.get("SHARED_NAME") == "value-from-b"
+        assert plugin_a.call_count == 1
+        assert plugin_b.call_count == 1
 
     def test_clear_specific_key(self):
         plugin = FakePlugin({"K": "v"})

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -39,6 +39,17 @@ class TestLogging:
             sk.get("NOPE")
         assert any(record.levelno == logging.WARNING for record in caplog.records)
 
+    def test_misbehaving_backend_exception_message_not_logged(self, caplog):
+        class LeakyPlugin(FakePlugin):
+            def get_secret(self, secret_name: str) -> str:
+                raise RuntimeError(f"failed with value=top-secret-leaked-{secret_name}")
+
+        sk = GenAIKeys(LeakyPlugin({}))
+        with caplog.at_level(logging.DEBUG, logger="genaikeys"), pytest.raises(RuntimeError):
+            sk.get("API_KEY")
+        joined = "\n".join(record.getMessage() for record in caplog.records)
+        assert "top-secret-leaked" not in joined
+
     def test_enable_logging_attaches_handler(self):
         from genaikeys import disable_logging, enable_logging
 


### PR DESCRIPTION
Implements Tier 1 critical roadmap items.

## Changes
- **BREAKING**: Removed `SingletonMeta` from `GenAIKeys`. Each instantiation now returns a fresh instance with its own private cache, eliminating cross-backend cache collisions by construction.
- Added context manager protocol: `with GenAIKeys.azure() as sk: ...` clears cached secrets on exit.
- Tightened log redaction: backend exception messages are no longer interpolated into log records — only the exception type name is logged, preventing a misbehaving backend from leaking secret values via logs.
- Removed dead `del os.environ[secret_name]` in `invalidate_cache`.
- New tests for instance isolation, context manager cache-clearing, and exception-message redaction.

Closes #9
Closes #10
Closes #12
Closes #15
